### PR TITLE
Fix logrotate access denied by shipping modified logrotate script

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -78,6 +78,12 @@ class vision_mysql::server (
     override_options        => deep_merge($default_override_options, $ssl_override_options),
   }
 
+  file { '/etc/logrotate.d/mysql-server':
+    ensure  => present,
+    content => template('vision_mysql/mysql-server.logrotate'),
+    require => Class['::mysql::server'],
+  }
+
   if ! empty($monitoring) {
     class { '::vision_mysql::server::monitoring':
       password => $monitoring['password'],

--- a/templates/mysql-server.logrotate
+++ b/templates/mysql-server.logrotate
@@ -1,0 +1,17 @@
+# Managed by Puppet; do not edit
+# adapted from debian mariadb-server: /etc/logrotate.d/mysql-server
+/var/log/mysql/mysql.log /var/log/mysql/mysql-slow.log /var/log/mysql/mariadb-slow.log /var/log/mysql/error.log {
+        hourly
+        rotate 7
+        missingok
+        create 640 mysql adm
+        compress
+        sharedscripts
+        postrotate
+          test -x /usr/bin/mysqladmin || exit 0
+          if [ -f `my_print_defaults --mysqld | grep -m 1 -oP "pid-file=\K.+$"` ]; then
+            mysqladmin --defaults-extra-file=/root/.my.cnf --local flush-error-log \
+              flush-engine-log flush-general-log flush-slow-log
+          fi
+        endscript
+}


### PR DESCRIPTION
Logrotate failed on MySQL logs with the following error message:
error: 'Access denied for user 'root'@'localhost' (using password: NO)'
error: error running shared postrotate script for '/var/log/mysql/mysql.log

Due to the fact that $HOME is not set in logrotate environment, mysqladmin
does not read /root/.my.cnf (mysql config file for root) where the login
credentials are provided.

This patch fixes it.